### PR TITLE
Fix IsMoving SDKCall on Windows

### DIFF
--- a/scripting/FixLagCompensation.sp
+++ b/scripting/FixLagCompensation.sp
@@ -65,7 +65,7 @@ public void OnPluginStart()
 		delete hGameData;
 		SetFailState("PrepSDKCall_SetFromConf(hGameData, SDKConf_Virtual, \"IsMoving\") failed!");
 	}
-	PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+	PrepSDKCall_SetReturnInfo(SDKType_Bool, SDKPass_Plain);
 	g_hIsMoving = EndPrepSDKCall();
 
 	delete hGameData;


### PR DESCRIPTION
The return value data type for the `bool CBaseEntity::IsMoving()` SDKCall is currently set to `SDKType_PlainOldData`. This works fine on Linux, but on Windows this causes the result to always be seen as true. Changing the data type to `SDKType_Bool` fixes this issue on Windows, and does not change the behaviour on Linux.

All of this was tested on CS:GO, but I don't foresee CS:S Linux behaving differently than CS:GO Linux in this regard.